### PR TITLE
OPS-7226 Change repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "s3"
   ],
   "author": "k1LoW <k1lowxb@gmail.com> (https://github.com/k1LoW)",
-  "repository": "k1LoW/serverless-s3-sync",
+  "repository": "https://github.com/Flaconi/serverless-s3-sync",
   "license": "MIT",
   "dependencies": {
     "@auth0/s3": "^1.0.0",


### PR DESCRIPTION
Updated repository URL to point to Flaconi's GitHub.